### PR TITLE
Python 3 compatibility

### DIFF
--- a/FastaUtils.py
+++ b/FastaUtils.py
@@ -7,17 +7,21 @@
 # and methods to load Fasta-formatted sequences from a file.
 #
 ################################################################################
-
+from __future__ import print_function, division, absolute_import, with_statement
 import re
-import string
 
 # transliterate for reverse complement
-trans = string.maketrans('ACGTacgt', 'TGCAtgca')
+try:
+    import string
+    trans = string.maketrans('ACGTacgt', 'TGCAtgca')
+except AttributeError:
+    trans = str.maketrans('ACGTacgt', 'TGCAtgca')
 # re for fasta header
 r = re.compile("^>(?P<name>\S+)(\s(?P<desc>.*))?")
 
+
 class Fasta(object):
-    ''' Simple class to store a fasta formatted sequence '''
+    """ Simple class to store a fasta formatted sequence """
     
     def __init__(self, name, desc, seq):
         self.name = name
@@ -27,7 +31,7 @@ class Fasta(object):
         self.length = len(seq)
         
     def __str__(self):
-        ''' Output FASTA format of sequence when 'print' method is called '''
+        """ Output FASTA format of sequence when 'print' method is called """
         s = []
         for i in range(0, self.length, 80):
             s.append(self.seq[i:i+80])
@@ -37,19 +41,20 @@ class Fasta(object):
             return ">%s\n%s" % (self.name, "\n".join(s))
     
     def reverse_complement(self):
-        ''' Reverse complement sequence, return new Fasta object '''
+        """ Reverse complement sequence, return new Fasta object """
         rcseq = self.seq[::-1].translate(trans)
         return Fasta(self.name, self.desc, rcseq)
-    
+
+
 def gcContent(seq):
-    '''return gc content'''
-    
+    """return gc content"""
     gc = seq.count('G') + seq.count('g')+ seq.count('c')+ seq.count('C')
     gcContent = float(gc) / len(seq)
     return gcContent
 
+
 def Nx0(listOfNumbers, x = 50):
-    '''return Nx0 of an given list of numbers'''
+    """return Nx0 of an given list of numbers"""
     listOfNumbers.sort(reverse=1)
     theorNx0 = sum(listOfNumbers) * x / 100
     
@@ -67,9 +72,9 @@ def Nx0(listOfNumbers, x = 50):
 
 
 def load(f):
-    ''' Parameter: HANDLE to input in Fasta format 
+    """ Parameter: HANDLE to input in Fasta format
         e.g. sys.stdin, or open(<file>)
-        Returns array of Fasta objects.'''
+        Returns array of Fasta objects."""
     name, desc, seq = '', '', ''
     seqs = []
     while True:
@@ -92,9 +97,8 @@ def load(f):
     return seqs
 
 
-
 if __name__ == "__main__":
     
     test = [10,20,30,40,50]
     m = Nx0(test, 50)
-    print m
+    print(m)

--- a/assemblyStatics.py
+++ b/assemblyStatics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function, division, absolute_import, with_statement
 __author__ = "Wenchao Lin"
 __copyright__ = "Copyright 2015, TBC"
 __license__ = "GPL"
@@ -7,18 +8,15 @@ __maintainer__ = "Wenchao Lin"
 __email__ = "linwenchao@yeah.net"
 __status__ = "Release"
 
-
 import FastaUtils
 import sys
 import re
 from optparse import OptionParser
 
-def run(options):
-    '''
-    
-    '''
 
-    
+def run(options):
+    """Main method for collecting all Fasta stats"""
+
     largeThreshold = options.large
 
     largestScaffoldName = ''
@@ -27,7 +25,6 @@ def run(options):
     totalGC = 0
     largeGC = 0
     lengthOfLargeSequence = 0
-    countOfNs = 0
     allLenList = []
     largeLenList = []
     contigList = []
@@ -57,12 +54,9 @@ def run(options):
         totalGC += seq.count('G') + seq.count('g')+ seq.count('c')+ seq.count('C')
         totalN += seq.count('N') + seq.count('n')
         
-    totalLength = sum(allLenList)
-    totalCount = len(allLenList)
-        
-    print '\nAll scaffold sequences summary:'
-    print '-----------------------------------'
-    say('Counts of scaffold sequences', totalCount)
+    print('\nAll scaffold sequences summary:')
+    print('-----------------------------------')
+    say('Counts of scaffold sequences', len(allLenList))
     say('Length of scaffold sequences', sum(allLenList))
     say('Largest scaffold name', largestScaffoldName)    
     say('Largest scaffold length', largestScaffoldLength)    
@@ -80,8 +74,8 @@ def run(options):
         sayPercent('N content (%)', 0)
         
     
-    print '\nLARGE (> %sbp) sequences summary:' % (largeThreshold)
-    print '-----------------------------------'
+    print('\nLARGE (> %sbp) sequences summary:' % (largeThreshold))
+    print('-----------------------------------')
     say('Counts of LARGE sequences', countOfLargeSequence)
     say('Length of LARGE sequences', lengthOfLargeSequence)
     say('LARGE scaffold N50', FastaUtils.Nx0(largeLenList, 50)[0])
@@ -98,8 +92,8 @@ def run(options):
         sayPercent('N content (%)', 0)        
         
     
-    print '\ncontigs summary:'
-    print '-----------------------------------'
+    print('\ncontigs summary:')
+    print('-----------------------------------')
     say('Counts of contigs',len(contigList))
     say('Maximum length of contigs',max(contigList))
     say('contig N50', FastaUtils.Nx0(contigList, 50)[0])
@@ -110,22 +104,17 @@ def run(options):
 
 
 def say(notes, value):
-    '''format output'''
+    """format output"""
     
-    print '%30s:\t%s' % (notes, value)
-    return 1
+    print('%30s:\t%s' % (notes, value))
 
 def sayPercent(notes, value):
-    '''Percent format output'''
-    
-    print '%30s:\t%.5s%%' % (notes, value)
-    return 1
-    
+    """Percent format output"""
+    print('%30s:\t%.5s%%' % (notes, value))
+
     
 def parseArgs():
-    '''
-    parse options
-    '''
+    """ parse options """
     usage = 'usage: %prog [options] -f INPUT.fasta'
     parser = OptionParser(usage = usage) 
     parser.add_option('-f', '--fasta', 
@@ -135,7 +124,7 @@ def parseArgs():
                       dest = 'large', default = 1000, type = int, 
                       help = 'Threshold of LARGE sequence [default = 1000]')
     
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
     if not options.fasta:
             parser.print_help()
             sys.exit()


### PR DESCRIPTION
Great tool!  I found it very helpful, but I'm using Python 3 in some projects.  This change uses  __future__ imports to make the code compatible with Python 2 and 3.  Tested on 2.7.11, 3.4 and 3.6.1.  